### PR TITLE
feat: add MyRentedToolListingList

### DIFF
--- a/listings/urls.py
+++ b/listings/urls.py
@@ -8,7 +8,8 @@ from listings import views
 
 urlpatterns = [
     path("tool-listings/", views.ToolListingList.as_view()),
-    path("tool-listings/mine/", views.MyToolListingList.as_view()),
+    path("tool-listings/my-rented-tools/", views.MyPublishedToolListingList.as_view()),
+    path("tool-listings/my-rentals/", views.MyPublishedToolListingList.as_view()),
     path("tool-listings/<int:pk>/", views.ToolListingDetail.as_view()),
     path("tool-listings/<int:pk>/rent/", views.ToolListingRent.as_view()),
     path("tool-listings/<int:pk>/unrent/", views.ToolListingUnrent.as_view()),

--- a/listings/views/__init__.py
+++ b/listings/views/__init__.py
@@ -4,7 +4,7 @@ from listings.views.listing_review_views import ReviewDetail
 from listings.views.listing_review_views import ReviewList
 from listings.views.past_tool_listing_views import PastToolListingDetail
 from listings.views.past_tool_listing_views import PastToolListingList
-from listings.views.tool_listing_views import MyToolListingList
+from listings.views.tool_listing_views import MyPublishedToolListingList
 from listings.views.tool_listing_views import ToolListingDetail
 from listings.views.tool_listing_views import ToolListingList
 from listings.views.tool_listing_views import ToolListingRent
@@ -13,7 +13,7 @@ from listings.views.tool_listing_views import ToolListingUnrent
 __all__ = [
     "ListingComplaintDetail",
     "ListingComplaintList",
-    "MyToolListingList",
+    "MyPublishedToolListingList",
     "PastToolListingDetail",
     "PastToolListingList",
     "ReviewDetail",

--- a/listings/views/tool_listing_views.py
+++ b/listings/views/tool_listing_views.py
@@ -4,6 +4,7 @@ from rest_framework import generics
 from base.permissions import BlockUnsafeMethods
 from listings.models import ToolListing
 from listings.models.past_tool_listing_models import PastToolListing
+from listings.serializers import PastToolListingSerializer
 from listings.serializers import ToolListingRentSerializer
 from listings.serializers import ToolListingSerializer
 from listings.serializers import ToolListingUnrentSerializer
@@ -44,10 +45,17 @@ class ToolListingUnrent(generics.UpdateAPIView, generics.GenericAPIView):
         return response
 
 
-class MyToolListingList(generics.ListAPIView):
+class MyPublishedToolListingList(generics.ListAPIView):
     serializer_class = ToolListingSerializer
     permission_classes = (BlockUnsafeMethods,)
 
     def get_queryset(self):
-        print("OK")
         return ToolListing.objects.filter(publisher=self.request.user)
+
+
+class MyRentedToolListingList(generics.ListAPIView):
+    serializer_class = PastToolListingSerializer
+    permission_classes = (BlockUnsafeMethods,)
+
+    def get_queryset(self):
+        return PastToolListing.objects.filter(renter=self.request.user)


### PR DESCRIPTION
This PR changes the /tool-listings/mine endpoint to /tool-listing/my-rented-tools and adds the /tool-listings/my-rentals.

The first endpoint gives the ToolListings published by the user, the second one gives the PastToolListings rented by the user.